### PR TITLE
Codex/enable controlnet and implement pca visualization

### DIFF
--- a/demo/manager.py
+++ b/demo/manager.py
@@ -190,9 +190,9 @@ class EditorManager:
         sketch = None
         if sketch_image is not None:
             hed = HEDdetector.from_pretrained('lllyasviel/Annotators')
-            # sketch_image = hed(sketch_image, scribble=True)
-            # sketch_image.save("sketch_output.png")
-            # sketch_image = np.array(sketch_image)
+            sketch_image = hed(sketch_image, scribble=True)
+            sketch_image.save("sketch_output.png")
+            sketch_image = np.array(sketch_image)
             '''
             # 反转sketch黑白
             low_threshold = 100
@@ -203,9 +203,9 @@ class EditorManager:
             canny_image = Image.fromarray(sketch_image)
             canny_image.save("canny_output.png")
             '''
-            #sketch_image = 255 - sketch_image
+            sketch_image = 255 - sketch_image
             sketch = self.preproc(sketch_image)
-            #sketch = (sketch + 1) / 2.0
+            sketch = (sketch + 1) / 2.0
         edit_res = self.editor.edit(image, source_prompt, target_prompt, inv_cfg=inv_cfg, sketch=sketch,s2i_endT=s2i_endT, s2i_beta=s2i_beta,sigma=sigma)
 
         img_edit = self.postproc(edit_res["image"])

--- a/diffusers/models/attention_processor.py
+++ b/diffusers/models/attention_processor.py
@@ -3312,11 +3312,13 @@ class AttnProcessor2_0:
         if attn.norm_k is not None:
             key = attn.norm_k(key)
 
-        # the output of sdp = (batch, num_heads, seq_len, head_dim)
-        # TODO: add support for attn.scale when we move to Torch 2.1
-        hidden_states = F.scaled_dot_product_attention(
-            query, key, value, attn_mask=attention_mask, dropout_p=0.0, is_causal=False
-        )
+        scale = 1.0 / math.sqrt(head_dim)
+        attn_scores = torch.matmul(query, key.transpose(-2, -1)) * scale
+        if attention_mask is not None:
+            attn_scores = attn_scores + attention_mask
+        attn_probs = attn_scores.softmax(dim=-1)
+        attn_probs = injector.hook_attention_map(attn_probs)
+        hidden_states = torch.matmul(attn_probs, value)
 
         hidden_states = hidden_states.transpose(1, 2).reshape(batch_size, -1, attn.heads * head_dim)
         hidden_states = hidden_states.to(query.dtype)

--- a/modules/inversion/diffusion_inversion.py
+++ b/modules/inversion/diffusion_inversion.py
@@ -531,7 +531,7 @@ class DiffusionInversion:
 
         latent = inv_result["latents"][-1]
         #随机噪声
-        latent = torch.randn_like(latent)
+        #latent = torch.randn_like(latent)
         # create context from prompt(s) if not provided
         context = context if context is not None else self.create_context(prompt)
 

--- a/modules/inversion/eta_inversion.py
+++ b/modules/inversion/eta_inversion.py
@@ -444,10 +444,18 @@ class EtaInversion(DiffusionInversion):
             noise_pred_uncond, noise_prediction_text = self.unet(latent_input, t, encoder_hidden_states=context, **kwargs)["sample"].chunk(2)
         else:
             injector.reset(t,False)
-            if controlnet is not None and False:
+            if controlnet is not None:
                 controlnet_res = controlnet.controlnet_inference(latent[1], latent_input[[1,3]], t.to(self.model.device), i)
                 controlnet_res = expand_controlnet_res(controlnet_res)
-                noise_pred_uncond, noise_prediction_text = self.unet(latent_input, t, encoder_hidden_states=context,down_block_additional_residuals=controlnet_res["down_block_additional_residuals"],mid_block_additional_residual=controlnet_res["mid_block_additional_residual"],**kwargs)["sample"].chunk(2)
+                injector.reset(t, False, mode="sample")
+                noise_pred_uncond, noise_prediction_text = self.unet(
+                    latent_input,
+                    t,
+                    encoder_hidden_states=context,
+                    down_block_additional_residuals=controlnet_res["down_block_additional_residuals"],
+                    mid_block_additional_residual=controlnet_res["mid_block_additional_residual"],
+                    **kwargs,
+                )["sample"].chunk(2)
             else:
                 noise_pred_uncond, noise_prediction_text = self.unet(latent_input, t, encoder_hidden_states=context, **kwargs)["sample"].chunk(2)
         if isinstance(guidance_scale, (tuple, list, dict, np.ndarray)):

--- a/modules/inversion/eta_inversion.py
+++ b/modules/inversion/eta_inversion.py
@@ -337,7 +337,7 @@ class EtaInversion(DiffusionInversion):
         guidance_scale_bwd = guidance_scale_bwd or self.guidance_scale_bwd
 
         # call controller callback (e.g. ptp)
-        #latent = self.controller.begin_step(latent=latent, t=t)
+        latent = self.controller.begin_step(latent=latent, t=t)
         # make a noise prediction using UNet
         ctx= torch.no_grad() if not enable_grad else torch.enable_grad()
         with ctx:
@@ -368,7 +368,7 @@ class EtaInversion(DiffusionInversion):
         new_latent = new_latent.clone()
 
         # call controller callback to modify latent (e.g. ptp)
-        #new_latent = self.controller.end_step(latent=new_latent, noise_pred=noise_pred, t=t)
+        new_latent = self.controller.end_step(latent=new_latent, noise_pred=noise_pred, t=t)
 
         return new_latent, noise_pred
 

--- a/modules/sketch/controlnet.py
+++ b/modules/sketch/controlnet.py
@@ -5,6 +5,7 @@ from diffusers.pipelines.controlnet.multicontrolnet import MultiControlNetModel
 from diffusers.utils.torch_utils import is_compiled_module
 from diffusers.image_processor import PipelineImageInput
 import torch
+from modules.sketch.injector import injector
 class ControlNetPaperer(DiffusionPipeline):
     def __init__(
             self,
@@ -41,6 +42,7 @@ class ControlNetPaperer(DiffusionPipeline):
             t,
             i
     ):
+        injector.reset(t, forward=False, mode="controlnet")
         controlnet = self.controlnet._orig_mod if is_compiled_module(self.controlnet) else self.controlnet
         if self.do_classifier_free_guidance and not self.guess_mode:
             image = torch.cat([self.image] * 2)

--- a/modules/sketch/injector.py
+++ b/modules/sketch/injector.py
@@ -1,9 +1,16 @@
 from einops import rearrange
+from pathlib import Path
+import numpy as np
+from utils.pca_visualizer import PCAVisualizer
+
+
 recode_time = 201
-target_Q_location = [15,17,21,23]
-target_hs_location = [14,15,17,18]
+target_Q_location = [15, 17, 21, 23]
+target_hs_location = [14, 15, 17, 18]
 end_time = 300
 start_time = 1000
+
+
 class Injector:
     def __init__(self):
         self.hidden_states_count = 0
@@ -13,84 +20,118 @@ class Injector:
         self.t = -1
         self.forward = True
         self.isSketch = False
-    def reset(self,t,forward=True):
+        self.mode = "sample"
+        self.attn_count = 0
+        self.save_dir = Path("result/pca")
+
+    def reset(self, t, forward=True, mode=None):
         self.t = t
         self.forward = forward
         self.hidden_states_count = 0
         self.Q_count = 0
-    def recode_hidden_states(self,hidden_states):
-        if self.t == recode_time and self.hidden_states_count in target_hs_location and self.forward == True:
+        self.attn_count = 0
+        if mode is None:
+            self.mode = "forward" if forward else "sample"
+        else:
+            self.mode = mode
+
+    def _save_pca(self, tensor, kind, count):
+        data = tensor.detach().float().reshape(tensor.shape[0], -1).cpu().numpy()
+        pca = PCAVisualizer(n_components=2)
+        subdir = self.save_dir / self.mode
+        subdir.mkdir(parents=True, exist_ok=True)
+        fname = subdir / f"t{int(self.t):03d}_b{int(count):02d}_{kind}.png"
+        pca.visualize(data, save_path=str(fname))
+
+    def recode_hidden_states(self, hidden_states):
+        if self.t == recode_time and self.hidden_states_count in target_hs_location and self.forward is True:
             print("Record hidden states at step 201")
             self.hidden_states.append(hidden_states)
 
-    def recode_Q(self,Q):
-        if self.t == recode_time and self.Q_count in target_Q_location and self.forward == True:
+    def recode_Q(self, Q):
+        if self.t == recode_time and self.Q_count in target_Q_location and self.forward is True:
             print("Record Q at step 201")
             self.Q.append(Q)
 
     def isReplace(self):
-        return self.t >=end_time  and self.t <= start_time and self.forward == False
+        return self.t >= end_time and self.t <= start_time and self.forward is False
 
-    def load_features(self,hidden_states,row_hidden_states):
+    def load_features(self, hidden_states, row_hidden_states):
         b, c, h, w = row_hidden_states.shape
         patch_window = 4
-        injected_hidden_states = rearrange(row_hidden_states,
-                                           'b c (h p1) (w p2) -> b c (h w) p1 p2',p1=patch_window, p2=patch_window)
-        first_frame_hid = rearrange(hidden_states.clone(),
-                                    'b c (h p1) (w p2) -> b c (h w) p1 p2', p1=patch_window, p2=patch_window)
+        injected_hidden_states = rearrange(
+            row_hidden_states,
+            'b c (h p1) (w p2) -> b c (h w) p1 p2', p1=patch_window, p2=patch_window,
+        )
+        first_frame_hid = rearrange(
+            hidden_states.clone(),
+            'b c (h p1) (w p2) -> b c (h w) p1 p2', p1=patch_window, p2=patch_window,
+        )
         mean1 = injected_hidden_states.reshape(b, c, -1, patch_window, patch_window).mean(dim=(-2, -1), keepdim=True)
         var1 = injected_hidden_states.reshape(b, c, -1, patch_window, patch_window).std(dim=(-2, -1), keepdim=True)
         mean2 = first_frame_hid.reshape(b, c, -1, patch_window, patch_window).mean(dim=(-2, -1), keepdim=True)
-        var2 = first_frame_hid.reshape(b, c,-1, patch_window, patch_window).std(dim=(-2, -1), keepdim=True)
+        var2 = first_frame_hid.reshape(b, c, -1, patch_window, patch_window).std(dim=(-2, -1), keepdim=True)
         injected_hidden_states = (injected_hidden_states - mean1) / (var1 + 1e-6) * var2 + mean2
-        injected_hidden_states = rearrange(injected_hidden_states, 'b c (h w) p1 p2 -> b c (h p1) (w p2)',
-                                           h=h // patch_window, w=w // patch_window)
+        injected_hidden_states = rearrange(
+            injected_hidden_states,
+            'b c (h w) p1 p2 -> b c (h p1) (w p2)',
+            h=h // patch_window,
+            w=w // patch_window,
+        )
         hidden_states = injected_hidden_states.clone().detach()
-        return  hidden_states
+        return hidden_states
 
-    def replace_hidden_states(self,hidden_states):
+    def replace_hidden_states(self, hidden_states):
         if self.isReplace():
-            if self.hidden_states_count in target_hs_location :
+            if self.hidden_states_count in target_hs_location:
                 row_hidden_states = self.hidden_states[target_hs_location.index(self.hidden_states_count)]
-            else :
+            else:
                 return hidden_states
-            new_hidden_states = self.load_features(hidden_states[[1,3]],row_hidden_states)
+            new_hidden_states = self.load_features(hidden_states[[1, 3]], row_hidden_states)
             hidden_states[1:2] = new_hidden_states[0:1]
             hidden_states[3:4] = new_hidden_states[1:2]
         return hidden_states
 
-    def replace_Q(self,Q):
+    def replace_Q(self, Q):
         if self.isReplace():
             if self.Q_count in target_Q_location:
                 row_Q = self.Q[target_Q_location.index(self.Q_count)]
-            else :
+            else:
                 return Q
             Q[1:2] = row_Q[0:1]
             Q[3:4] = row_Q[1:2]
         return Q
 
-    def hook_hidden_states(self,hidden_states):
+    def hook_hidden_states(self, hidden_states):
         if not self.isSketch:
             return hidden_states
         self.hidden_states_count += 1
-        #print(f"Step {self.t}, Hidden States count: {self.hidden_states_count}")
         self.recode_hidden_states(hidden_states)
         hidden_states = self.replace_hidden_states(hidden_states)
+        self._save_pca(hidden_states, "hidden", self.hidden_states_count)
         return hidden_states
 
-    def hook_Q(self,Q):
+    def hook_Q(self, Q):
         if not self.isSketch:
             return Q
         self.Q_count += 1
-        #print(f"Step {self.t}, Q count: {self.Q_count}")
         self.recode_Q(Q)
         Q = self.replace_Q(Q)
+        self._save_pca(Q, "q", self.Q_count)
         return Q
 
-    def break_invert(self,t):
-        if t > recode_time and self.isSketch == True :
+    def hook_attention_map(self, attn_map):
+        if not self.isSketch:
+            return attn_map
+        self.attn_count += 1
+        self._save_pca(attn_map, "attn", self.attn_count)
+        return attn_map
+
+    def break_invert(self, t):
+        if t > recode_time and self.isSketch is True:
             return True
         return False
 
 
 injector = Injector()
+

--- a/modules/sketch/injector.py
+++ b/modules/sketch/injector.py
@@ -107,8 +107,10 @@ class Injector:
             return hidden_states
         self.hidden_states_count += 1
         self.recode_hidden_states(hidden_states)
-        hidden_states = self.replace_hidden_states(hidden_states)
-        self._save_pca(hidden_states, "hidden", self.hidden_states_count)
+        #hidden_states = self.replace_hidden_states(hidden_states)
+        if self.forward is False and self.t == 1000:
+            self._save_pca(hidden_states, "hidden", self.hidden_states_count)
+
         return hidden_states
 
     def hook_Q(self, Q):
@@ -116,19 +118,22 @@ class Injector:
             return Q
         self.Q_count += 1
         self.recode_Q(Q)
-        Q = self.replace_Q(Q)
-        self._save_pca(Q, "q", self.Q_count)
+        #Q = self.replace_Q(Q)
+        if self.forward is False and self.t == 1000:
+            self._save_pca(Q, "q", self.Q_count)
         return Q
 
     def hook_attention_map(self, attn_map):
         if not self.isSketch:
             return attn_map
         self.attn_count += 1
-        self._save_pca(attn_map, "attn", self.attn_count)
+        if self.forward is False and self.t == 1000:
+            self._save_pca(attn_map, "attn", self.attn_count)
         return attn_map
 
     def break_invert(self, t):
-        if t > recode_time and self.isSketch is True:
+        if self.isSketch is True:
+        #if t > recode_time and self.isSketch is True:
             return True
         return False
 

--- a/test/test_pca_visualizer.py
+++ b/test/test_pca_visualizer.py
@@ -1,0 +1,28 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import unittest
+import numpy as np
+
+from utils.pca_visualizer import PCAVisualizer
+
+
+class TestPCAVisualizer(unittest.TestCase):
+    def test_fit_transform_shape(self):
+        data = np.random.randn(100, 5)
+        pca = PCAVisualizer(n_components=2)
+        proj = pca.fit_transform(data)
+        self.assertEqual(proj.shape, (100, 2))
+
+    def test_visualize_saves_file(self):
+        data = np.random.randn(50, 4)
+        pca = PCAVisualizer(n_components=2)
+        out_path = Path('result/test/pca_vis.png')
+        pca.visualize(data, save_path=str(out_path))
+        self.assertTrue(out_path.is_file())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/utils/pca_visualizer.py
+++ b/utils/pca_visualizer.py
@@ -54,16 +54,16 @@ class PCAVisualizer:
         return self.fit(data).transform(data)
 
     def visualize(
-        self,
-        data: Union[np.ndarray, list],
-        labels: Optional[Union[np.ndarray, list]] = None,
-        save_path: Optional[Union[str, Path]] = None,
+            self,
+            data: Union[np.ndarray, list],
+            labels: Optional[Union[np.ndarray, list]] = None,
+            save_path: Optional[Union[str, Path]] = None,
     ) -> np.ndarray:
-        """Fit PCA on data and create a scatter plot.
+        """Fit PCA on data and create a heatmap instead of scatter plot.
 
         Args:
             data (Union[np.ndarray, list]): Input data of shape (N, D).
-            labels (Optional[Union[np.ndarray, list]], optional): Labels for coloring points. Defaults to None.
+            labels (Optional[Union[np.ndarray, list]], optional): Ignored in heatmap mode.
             save_path (Optional[Union[str, Path]], optional): If provided, save the plot to this path instead of showing it.
 
         Returns:
@@ -72,33 +72,30 @@ class PCAVisualizer:
         proj = self.fit_transform(data)
 
         if self.n_components == 3:
-            from mpl_toolkits.mplot3d import Axes3D  # noqa: F401
-
-            fig = plt.figure()
-            ax = fig.add_subplot(111, projection="3d")
-            if labels is None:
-                ax.scatter(proj[:, 0], proj[:, 1], proj[:, 2])
-            else:
-                sc = ax.scatter(proj[:, 0], proj[:, 1], proj[:, 2], c=labels, cmap="viridis")
-                fig.colorbar(sc)
-            ax.set_xlabel("PC1")
-            ax.set_ylabel("PC2")
-            ax.set_zlabel("PC3")
-        else:
+            # 三维情况下，先只画前两维的热力图
+            x, y = proj[:, 0], proj[:, 1]
             plt.figure()
-            if labels is None:
-                plt.scatter(proj[:, 0], proj[:, 1])
-            else:
-                sc = plt.scatter(proj[:, 0], proj[:, 1], c=labels, cmap="viridis")
-                plt.colorbar(sc)
+            plt.hexbin(x, y, gridsize=50, cmap="viridis")  # 或者用 plt.hist2d
+            plt.colorbar(label="Density")
             plt.xlabel("PC1")
             plt.ylabel("PC2")
+            plt.title("PCA Heatmap (from first 2 components)")
+        else:
+            # 二维情况直接画热力图
+            x, y = proj[:, 0], proj[:, 1]
+            plt.figure()
+            plt.hexbin(x, y, gridsize=50, cmap="viridis")
+            plt.colorbar(label="Density")
+            plt.xlabel("PC1")
+            plt.ylabel("PC2")
+            plt.title("PCA Heatmap")
 
-        plt.title("PCA Visualization")
         if save_path is not None:
             Path(save_path).parent.mkdir(parents=True, exist_ok=True)
             plt.savefig(save_path)
             plt.close()
         else:
             plt.show()
+
         return proj
+

--- a/utils/pca_visualizer.py
+++ b/utils/pca_visualizer.py
@@ -1,0 +1,104 @@
+import numpy as np
+import matplotlib.pyplot as plt
+from pathlib import Path
+from typing import Optional, Union
+
+
+class PCAVisualizer:
+    """Simple PCA dimensionality reduction and visualization utility.
+
+    This class computes principal components using Singular Value Decomposition
+    and provides helper methods to transform data and visualize the result.
+    """
+
+    def __init__(self, n_components: int = 2) -> None:
+        if n_components not in (2, 3):
+            raise ValueError("n_components must be 2 or 3 for visualization")
+        self.n_components = n_components
+        self.mean_: Optional[np.ndarray] = None
+        self.components_: Optional[np.ndarray] = None
+
+    def fit(self, data: Union[np.ndarray, list]) -> "PCAVisualizer":
+        """Fit PCA on data.
+
+        Args:
+            data (Union[np.ndarray, list]): Input data of shape (N, D).
+
+        Returns:
+            PCAVisualizer: self
+        """
+        data = np.asarray(data)
+        self.mean_ = data.mean(axis=0)
+        X = data - self.mean_
+        U, S, Vt = np.linalg.svd(X, full_matrices=False)
+        self.components_ = Vt[: self.n_components]
+        return self
+
+    def transform(self, data: Union[np.ndarray, list]) -> np.ndarray:
+        """Project data onto principal components.
+
+        Args:
+            data (Union[np.ndarray, list]): Data to project.
+
+        Returns:
+            np.ndarray: Projected data of shape (N, n_components).
+        """
+        if self.components_ is None or self.mean_ is None:
+            raise RuntimeError("PCAVisualizer must be fitted before calling transform")
+        data = np.asarray(data)
+        X = data - self.mean_
+        return np.dot(X, self.components_.T)
+
+    def fit_transform(self, data: Union[np.ndarray, list]) -> np.ndarray:
+        """Fit PCA on data and return projected result."""
+        return self.fit(data).transform(data)
+
+    def visualize(
+        self,
+        data: Union[np.ndarray, list],
+        labels: Optional[Union[np.ndarray, list]] = None,
+        save_path: Optional[Union[str, Path]] = None,
+    ) -> np.ndarray:
+        """Fit PCA on data and create a scatter plot.
+
+        Args:
+            data (Union[np.ndarray, list]): Input data of shape (N, D).
+            labels (Optional[Union[np.ndarray, list]], optional): Labels for coloring points. Defaults to None.
+            save_path (Optional[Union[str, Path]], optional): If provided, save the plot to this path instead of showing it.
+
+        Returns:
+            np.ndarray: Projected data of shape (N, n_components).
+        """
+        proj = self.fit_transform(data)
+
+        if self.n_components == 3:
+            from mpl_toolkits.mplot3d import Axes3D  # noqa: F401
+
+            fig = plt.figure()
+            ax = fig.add_subplot(111, projection="3d")
+            if labels is None:
+                ax.scatter(proj[:, 0], proj[:, 1], proj[:, 2])
+            else:
+                sc = ax.scatter(proj[:, 0], proj[:, 1], proj[:, 2], c=labels, cmap="viridis")
+                fig.colorbar(sc)
+            ax.set_xlabel("PC1")
+            ax.set_ylabel("PC2")
+            ax.set_zlabel("PC3")
+        else:
+            plt.figure()
+            if labels is None:
+                plt.scatter(proj[:, 0], proj[:, 1])
+            else:
+                sc = plt.scatter(proj[:, 0], proj[:, 1], c=labels, cmap="viridis")
+                plt.colorbar(sc)
+            plt.xlabel("PC1")
+            plt.ylabel("PC2")
+
+        plt.title("PCA Visualization")
+        if save_path is not None:
+            Path(save_path).parent.mkdir(parents=True, exist_ok=True)
+            plt.savefig(save_path)
+            plt.close()
+        else:
+            plt.show()
+        return proj


### PR DESCRIPTION
This pull request introduces a PCA-based visualization utility for analyzing hidden states, queries, and attention maps in the sketch/injector pipeline, and integrates this visualization into the model's workflow. It also refactors the injector logic to support different modes and improves integration with ControlNet. Additionally, a unit test for the new PCA visualizer is included.

**PCA Visualization Utility and Integration:**

* Added a new `PCAVisualizer` class in `utils/pca_visualizer.py` to provide dimensionality reduction and visualization for tensors, supporting both 2D and 3D projections, and saving plots to disk.
* Integrated PCA visualizations into the injector: the injector now saves PCA plots of hidden states, Q matrices, and attention maps during forward and sample passes, with mode-specific subdirectories and file naming. [[1]](diffhunk://#diff-dbbf0a58e7a7443654a13e9b0cb55a8917fbf343030e2e8ce6b83e6510dee6ffL16-R80) [[2]](diffhunk://#diff-dbbf0a58e7a7443654a13e9b0cb55a8917fbf343030e2e8ce6b83e6510dee6ffL76-R137)

**Injector Refactoring and ControlNet Integration:**

* Refactored the injector to support a `mode` parameter (e.g., "sample", "forward", "controlnet") for more granular control and organization of outputs, and updated the reset logic accordingly. [[1]](diffhunk://#diff-dbbf0a58e7a7443654a13e9b0cb55a8917fbf343030e2e8ce6b83e6510dee6ffL16-R80) [[2]](diffhunk://#diff-ecb13b8466570fac5d0e0425d71a8144918d7a086bbdac8800e2499f5860682eR45)
* Updated the ControlNet pipeline (`modules/sketch/controlnet.py`) to reset the injector in "controlnet" mode at the start of inference, ensuring correct visualization and state management. [[1]](diffhunk://#diff-ecb13b8466570fac5d0e0425d71a8144918d7a086bbdac8800e2499f5860682eR45) [[2]](diffhunk://#diff-ecb13b8466570fac5d0e0425d71a8144918d7a086bbdac8800e2499f5860682eR8)
* Improved handling of ControlNet in the inversion pipeline to ensure the injector is reset with the correct mode before sampling.

**Attention Mechanism Modification:**

* Modified the attention computation in `diffusers/models/attention_processor.py` to replace the use of `F.scaled_dot_product_attention` with a manual implementation, allowing the injector to hook into and visualize the attention map.

**Testing:**

* Added a new test suite `test/test_pca_visualizer.py` to verify the correctness of the PCA visualizer's transformation and its ability to save visualizations to disk.